### PR TITLE
Update the project to compile by changing the Fyrox version to 0.34.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ inherits = "release"
 opt-level = 3
 
 [workspace.dependencies.fyrox]
-path = "../Fyrox/fyrox"
+version = "0.34.0"
 default-features = false
 [workspace.dependencies.fyroxed_base]
-path = "../Fyrox/editor"
+version = "0.21.0"
 default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fyrox = { version = "0.33.1", path = "../../Fyrox/fyrox" }
+fyrox = { workspace = true }
 fish_fall = { path = "../game", optional = true }
 
 [features]


### PR DESCRIPTION
I cloned this repository and placed the Fyrox engine next to it, but encountered a compilation error. To fix this, I modified the project based on the `fyrox_test` example generated by `fyrox-template init --name fyrox_test --style 2d`, and it works now.

Here's the error message with Fyrox tag v0.33:
```
PS C:\files\lab\FishFolly> cargo run --package executor --release
error: failed to load manifest for workspace member `C:\files\lab\FishFolly\editor`
referenced by workspace at `C:\files\lab\FishFolly\Cargo.toml`

Caused by:
  failed to load manifest for dependency `fish_fall`

Caused by:
  failed to load manifest for dependency `fyrox`

Caused by:
  failed to read `C:\files\lab\Fyrox\fyrox\Cargo.toml`

Caused by:
  The system cannot find the path specified. (os error 3)
```